### PR TITLE
Handle no active context

### DIFF
--- a/core/lib/DomStorageTracker.ts
+++ b/core/lib/DomStorageTracker.ts
@@ -167,7 +167,7 @@ export default class DomStorageTracker extends TypedEventEmitter<IDomStorageEven
       result.push(record);
 
       try {
-        record.frame = this.page.frames.find(x => x.securityOrigin === origin);
+        record.frame = this.page.frames.find(x => x.securityOrigin === origin && x.isAttached);
 
         if (record.frame && !record.databaseNames.length) {
           const { databaseNames } = await this.devtoolsSession.send(
@@ -180,6 +180,7 @@ export default class DomStorageTracker extends TypedEventEmitter<IDomStorageEven
         }
       } catch (err) {
         // can throw if document not found in page
+        record.frame = null;
       }
     }
     return result;


### PR DESCRIPTION
When a Frame does a “evaluate”, we had a situation where no activeContextId would be found. The evaluate was trying to go forward without a context. It should instead throw an error.

Improves reliability of https://github.com/ulixee/hero/issues/135