### PR TITLE
fix(core): force x86 chrome on m1

### DIFF
--- a/core/env.ts
+++ b/core/env.ts
@@ -19,6 +19,7 @@ export default {
       .find(x => x.match(/^@ulixee\/chrome-\d+-0$/))
       ?.split('@ulixee/')
       ?.pop(),
+  noRosettaChromeOnMac: booleanOrUndefined(process.env.UBK_NO_CHROME_ROSETTA)
 };
 
 function booleanOrUndefined(envValue): boolean | undefined {


### PR DESCRIPTION
We are using a version of Chrome that has code signing stripped out of it. This unfortunately means M1 refuses to launch it (code must be signed to run on the processor). I could not figure out code signing of Chrome, which I think is likely the longterm fix. In order to workaround being able to function on an m1 for now without developer prompts, the best option seems to be to force x86. 

Should a developer wish to run natively, they can work around the defaults by:
 - ad hoc signing chrome `sudo codesign -f -s --deep --force - "~/Library/Caches/ulixee/chrome/X.X.X.X/Google Chrome.app"` (note: replace version in path). 
 - and opt out of forcing Rosetta with environment variable: `UBK_NO_CHROME_ROSETTA=true`

Addresses #7