### PR TITLE
fix(mitm): try to handle socket timeouts

### DIFF
--- a/core/lib/Pool.ts
+++ b/core/lib/Pool.ts
@@ -109,12 +109,10 @@ export default class Pool extends TypedEventEmitter<{
   }
 
   public async createMitmProxy(): Promise<MitmProxy> {
-    if (!this.certificateGenerator) {
-      this.certificateGenerator = MitmProxy.createCertificateGenerator(
-        this.options.certificateStore,
-        this.options.dataDir,
-      );
-    }
+    this.certificateGenerator ??= MitmProxy.createCertificateGenerator(
+      this.options.certificateStore,
+      this.options.dataDir,
+    );
     return await MitmProxy.start(this.certificateGenerator);
   }
 
@@ -171,7 +169,10 @@ export default class Pool extends TypedEventEmitter<{
       }
       this.browsersById.clear();
 
-      if (this.certificateGenerator) this.certificateGenerator.close();
+      if (this.certificateGenerator) {
+        this.certificateGenerator.close();
+        this.certificateGenerator = null;
+      }
 
       if (this.mitmStartPromise) {
         this.mitmStartPromise.then(x => x.close()).catch(err => err);

--- a/mitm-socket/lib/CertificateGenerator.ts
+++ b/mitm-socket/lib/CertificateGenerator.ts
@@ -16,7 +16,6 @@ export default class CertificateGenerator extends BaseIpcHandler {
   protected logger: IBoundLog = log.createChild(module);
 
   private pendingCertsById = new Map<number, Resolvable<{ cert: string; expireDate: number }>>();
-
   private privateKey: Buffer;
   private waitForInit = new Resolvable<void>();
   private hasWaitForInitListeners = false;
@@ -35,6 +34,7 @@ export default class CertificateGenerator extends BaseIpcHandler {
   }
 
   public async getCertificate(host: string): Promise<{ cert: Buffer; key: Buffer }> {
+    if (this.isClosing) return { key: null, cert: null };
     await this.waitForConnected;
     const existing = this.store?.get(host);
     if (existing) {

--- a/mitm-socket/test/MitmSocket.test.ts
+++ b/mitm-socket/test/MitmSocket.test.ts
@@ -6,7 +6,6 @@ import * as WebSocket from 'ws';
 import { getTlsConnection, httpGetWithSocket } from '@unblocked-web/agent-testing/helpers';
 import * as https from 'https';
 import { IncomingMessage } from 'http';
-import * as tls from 'tls';
 import MitmSocket from '../index';
 import MitmSocketSession from '../lib/MitmSocketSession';
 

--- a/mitm/handlers/RequestSession.ts
+++ b/mitm/handlers/RequestSession.ts
@@ -112,8 +112,7 @@ export default class RequestSession
       x => resource.requestTime - x.responseTime < 5e3,
     );
     if (redirect) {
-      const redirectChain = [redirect.url, ...redirect.redirectChain];
-      resourceRedirect.redirectChain = redirectChain;
+      resourceRedirect.redirectChain = [redirect.url, ...redirect.redirectChain];
     }
   }
 
@@ -131,7 +130,7 @@ export default class RequestSession
   }
 
   public async lookupDns(host: string): Promise<string> {
-    if (this.dns) {
+    if (this.dns && !this.isClosing) {
       try {
         return await this.dns.lookupIp(host);
       } catch (error) {

--- a/mitm/test/MitmRequestAgent.test.ts
+++ b/mitm/test/MitmRequestAgent.test.ts
@@ -6,11 +6,12 @@ import * as WebSocket from 'ws';
 import * as HttpProxyAgent from 'http-proxy-agent';
 import { Helpers, TestLogger } from '@unblocked-web/agent-testing';
 import { getProxyAgent, runHttpsServer } from '@unblocked-web/agent-testing/helpers';
+import CertificateGenerator from '@unblocked-web/agent-mitm-socket/lib/CertificateGenerator';
 import MitmServer from '../lib/MitmProxy';
 import RequestSession from '../handlers/RequestSession';
 import HeadersHandler from '../handlers/HeadersHandler';
 import MitmRequestAgent from '../lib/MitmRequestAgent';
-import env from '../env';
+import { MitmProxy } from '../index';
 
 const mocks = {
   HeadersHandler: {
@@ -18,7 +19,10 @@ const mocks = {
   },
 };
 
+let certificateGenerator: CertificateGenerator;
+
 beforeAll(() => {
+  certificateGenerator = MitmProxy.createCertificateGenerator();
   mocks.HeadersHandler.determineResourceType.mockImplementation(async () => {
     return {
       resourceType: 'Document',
@@ -255,7 +259,7 @@ test('it should reuse http2 connections', async () => {
 });
 
 async function startMitmServer() {
-  const mitmServer = await MitmServer.start();
+  const mitmServer = await MitmServer.start(certificateGenerator);
   Helpers.onClose(() => mitmServer.close());
   return mitmServer;
 }

--- a/mitm/test/http2.test.ts
+++ b/mitm/test/http2.test.ts
@@ -5,6 +5,7 @@ import { URL } from 'url';
 import MitmSocket from '@unblocked-web/agent-mitm-socket';
 import IHttpHeaders from '@unblocked-web/specifications/agent/net/IHttpHeaders';
 import MitmSocketSession from '@unblocked-web/agent-mitm-socket/lib/MitmSocketSession';
+import CertificateGenerator from '@unblocked-web/agent-mitm-socket/lib/CertificateGenerator';
 import MitmServer from '../lib/MitmProxy';
 import RequestSession from '../handlers/RequestSession';
 import HttpRequestHandler from '../handlers/HttpRequestHandler';
@@ -13,6 +14,7 @@ import MitmRequestContext from '../lib/MitmRequestContext';
 import { parseRawHeaders } from '../lib/Utils';
 import CacheHandler from '../handlers/CacheHandler';
 import env from '../env';
+import { MitmProxy } from '../index';
 
 const mocks = {
   httpRequestHandler: {
@@ -26,7 +28,10 @@ const mocks = {
   },
 };
 
+let certificateGenerator: CertificateGenerator;
+
 beforeAll(() => {
+  certificateGenerator = MitmProxy.createCertificateGenerator();
   mocks.HeadersHandler.determineResourceType.mockImplementation(async () => {
     return {
       resourceType: 'Document',
@@ -228,7 +233,7 @@ test('should send trailers', async () => {
 
 async function createH2Connection(sessionIdPrefix: string, url: string) {
   const hostUrl = new URL(url);
-  const mitmServer = await MitmServer.start();
+  const mitmServer = await MitmServer.start(certificateGenerator);
   Helpers.onClose(() => mitmServer.close());
 
   const session = createSession(mitmServer, sessionIdPrefix);


### PR DESCRIPTION
I couldn't reproduce the error reported in Hero Issue [169](https://github.com/ulixee/hero/issues/169). My theory is that it's occurring AFTER Agent attempts to close, but that a timing issue is allowing a socket to attempt to connect after the mitm/RequestSession and MitmSocket are "Closed". This PR adds a few cases of stopping new connects from occurring after close so they can't get "lost" during closeup.

There was also an issue where certificate generators were being double-created during tests that is fixed in this PR.